### PR TITLE
Bugfix word elements not wrapping

### DIFF
--- a/src/assets/config/custom-styles.css
+++ b/src/assets/config/custom-styles.css
@@ -1,7 +1,3 @@
-.w .lb {
-    display: none;
-}
-
 .ab[rend="align-center"] {
     display: block;
     text-align: center;

--- a/src/assets/config/file_config_DOTR.json
+++ b/src/assets/config/file_config_DOTR.json
@@ -1,6 +1,10 @@
 {
 	"editionUrls": [
-		"assets/data/VB-DOTR.xml"
+		{
+			"type": "main",
+			"value":"assets/data/custom/DOTR/VB-complete-xinclude.xml",
+			"enable": true
+		}
 	],
 	"editionImagesSource": {
 		"manifest": {

--- a/src/assets/config/file_config_Pelavicino.json
+++ b/src/assets/config/file_config_Pelavicino.json
@@ -1,6 +1,10 @@
 {
 	"editionUrls": [
-		"assets/data/pelavicino.xml"
+		{
+			"type": "main",
+			"value": "assets/data/pelavicino.xml",
+			"enable": true
+		}
 	],
 	"editionImagesSource": {
 		"manifest": {

--- a/src/assets/config/file_config_PseudoEdition.json
+++ b/src/assets/config/file_config_PseudoEdition.json
@@ -1,6 +1,10 @@
 {
 	"editionUrls": [
-		"assets/data/pseudoEdition.xml"
+		{
+			"type": "main",
+			"value": "assets/data/pseudoEdition.xml",
+			"enable": true
+		}
 	],
 	"editionImagesSource": {
 		"manifest": {

--- a/src/assets/config/file_config_Saba.json
+++ b/src/assets/config/file_config_Saba.json
@@ -1,6 +1,11 @@
 {
 	"editionUrls": [
-		"assets/data/saba.xml"
+		{
+			"type": "main",
+			"value": "assets/data/saba.xml",
+			"enable": true
+		}
+		
 	],
 	"editionImagesSource": {
 		"manifest": {


### PR DESCRIPTION
There was a style setting `<lb/>` as `block: none` if inside a `<w/>` element, so we removed it and the default behavior of `<lb/>`  has been restored