### PR TITLE
Bugfix some apparatus entries were skipped

### DIFF
--- a/src/app/components/critical-apparatus/critical-apparatus.component.ts
+++ b/src/app/components/critical-apparatus/critical-apparatus.component.ts
@@ -22,11 +22,12 @@ export class CriticalApparatusComponent {
   ]).pipe(
     map(([appEntries, selectedAppEntries]) => {
       const apparatusEntries = appEntries as ApparatusEntry[];
-      const result = apparatusEntries.map(entry => {
+      const apps = apparatusEntries.map(entry => {
         const selectedApp = selectedAppEntries.find(app => app.additionalAttributes.exponentId === entry.additionalAttributes.exponentId);
         return { entry, isSelected: !!selectedApp };
       });
-      return result;
+      const orderedApps = apps.sort((a, b) => a.entry.exponent.localeCompare(b.entry.exponent))
+      return orderedApps;
     }),
     tap(result => {
       const selectedIndex = result.findIndex(x => x.isSelected);

--- a/src/app/components/critical-apparatus/critical-apparatus.component.ts
+++ b/src/app/components/critical-apparatus/critical-apparatus.component.ts
@@ -26,7 +26,13 @@ export class CriticalApparatusComponent {
         const selectedApp = selectedAppEntries.find(app => app.additionalAttributes.exponentId === entry.additionalAttributes.exponentId);
         return { entry, isSelected: !!selectedApp };
       });
-      const orderedApps = apps.sort((a, b) => a.entry.exponent.localeCompare(b.entry.exponent))
+      const orderedApps = apps.sort((a, b) => {
+        const lengthComparison = a.entry.exponent.length - b.entry.exponent.length;
+        if (lengthComparison !== 0) {
+          return lengthComparison;
+        }
+        return a.entry.exponent.localeCompare(b.entry.exponent);
+      });
       return orderedApps;
     }),
     tap(result => {

--- a/src/app/services/xml-parsers/structure-xml-parser.service.ts
+++ b/src/app/services/xml-parsers/structure-xml-parser.service.ts
@@ -259,30 +259,32 @@ export class StructureXmlParserService {
       }
       else if (item.type?.name === 'Anchor') {
         const anchorId = item.attributes['id'];
-        const app = this.getApparatusEntryOrDefault(anchorId);
-        if (!app) {
+        const apps = this.getApparatusEntriesOrDefault(anchorId);
+        if (!apps.length) {
           console.warn("This anchor has not apparatus entry associated with its id and will be skipped", item);
           continue;
         }
 
-        const appFrom = Attribute.createOrDefault(app.attributes[FROM_ATTRIBUTE]);
-        if (!appFrom) {
-          throw new Error(`A standoff apparatus entry must have a valid ${FROM_ATTRIBUTE} attribute`);
-        }
+        for (const app of apps) {
+          const appFrom = Attribute.createOrDefault(app.attributes[FROM_ATTRIBUTE]);
+          if (!appFrom) {
+            throw new Error(`A standoff apparatus entry must have a valid ${FROM_ATTRIBUTE} attribute`);
+          }
 
-        const appTo = Attribute.createOrDefault(app.attributes[TO_ATTRIBUTE]);
-        const isToAnchor = appTo && appTo.equals(anchorId);
-        if (!isToAnchor) {
-          //console.log("This anchor will be skipped because is the starting anchor, exponent will be place on the ending anchor", item);
-          continue;
-        }
+          const appTo = Attribute.createOrDefault(app.attributes[TO_ATTRIBUTE]);
+          const isToAnchor = appTo && appTo.equals(anchorId);
+          if (!isToAnchor) {
+            //console.log("This anchor will be skipped because is the starting anchor, exponent will be place on the ending anchor", item);
+            continue;
+          }
 
-        const id = this.getExponentId();
-        const exponent = ApparatusEntryExponent.create(id, appFrom.valueWithoutRef, appTo.valueWithoutRef, getExponentLabel(), app);
-        // insert at index
-        items.splice(i + 1, 0, exponent);
-        this.appExponents.set(exponent.id().valueWithoutRef, exponent);
-        app.exponent = exponent.label;
+          const id = this.getExponentId();
+          const exponent = ApparatusEntryExponent.create(id, appFrom.valueWithoutRef, appTo.valueWithoutRef, getExponentLabel(), app);
+          // insert at index
+          items.splice(i + 1, 0, exponent);
+          this.appExponents.set(exponent.id().valueWithoutRef, exponent);
+          app.exponent = exponent.label;
+        }
       }
       // in other cases exponents are added to the items array, so we skip them
       else if (item.type?.name === 'ApparatusEntryExponent') {
@@ -295,31 +297,33 @@ export class StructureXmlParserService {
 
         // now check if the item itself has an apparatus entry and add it's exponent as last child
         const itemId = item.attributes['id'];
-        const app = this.getApparatusEntryOrDefault(itemId);
-        if (!app) {
+        const apps = this.getApparatusEntriesOrDefault(itemId);
+        if (!apps.length) {
           //console.log("This item has no apparatus entry, skipping", item);
           continue;
         }
 
-        const id = this.getExponentId();
-        const appFrom = Attribute.createOrDefault(app.attributes[FROM_ATTRIBUTE]);
-        const appTo = Attribute.createOrDefault(app.attributes[TO_ATTRIBUTE]);
-        const isToElement = appTo && appTo.valueWithoutRef === itemId;
-        if (isToElement) {
-          const from = appFrom.valueWithoutRef;
-          const to = id; // the exponent will be the To element itself since is placed as next sibling of the current item
-          const exponent = ApparatusEntryExponent.create(id, from, to, getExponentLabel(), app);
-          items.splice(i + 1, 0, exponent); // insert as sibling because this component is not an anchor
-          this.appExponents.set(exponent.id().valueWithoutRef, exponent);
-          app.exponent = exponent.label;
-        }
-        else if (!appTo) {
-          const from = itemId; // from itself since the apparatus entry refer to it
-          const to = id; // the exponent will be place as the last child of the element so it marks the end
-          const exponent = ApparatusEntryExponent.create(id, from, to, getExponentLabel(), app);
-          item.content.push(exponent);
-          this.appExponents.set(exponent.id().valueWithoutRef, exponent);
-          app.exponent = exponent.label;
+        for (const app of apps) {
+          const id = this.getExponentId();
+          const appFrom = Attribute.createOrDefault(app.attributes[FROM_ATTRIBUTE]);
+          const appTo = Attribute.createOrDefault(app.attributes[TO_ATTRIBUTE]);
+          const isToElement = appTo && appTo.valueWithoutRef === itemId;
+          if (isToElement) {
+            const from = appFrom.valueWithoutRef;
+            const to = id; // the exponent will be the To element itself since is placed as next sibling of the current item
+            const exponent = ApparatusEntryExponent.create(id, from, to, getExponentLabel(), app);
+            items.splice(i + 1, 0, exponent); // insert as sibling because this component is not an anchor
+            this.appExponents.set(exponent.id().valueWithoutRef, exponent);
+            app.exponent = exponent.label;
+          }
+          else if (!appTo) {
+            const from = itemId; // from itself since the apparatus entry refer to it
+            const to = id; // the exponent will be place as the last child of the element so it marks the end
+            const exponent = ApparatusEntryExponent.create(id, from, to, getExponentLabel(), app);
+            item.content.push(exponent);
+            this.appExponents.set(exponent.id().valueWithoutRef, exponent);
+            app.exponent = exponent.label;
+          }
         }
       }
       else {
@@ -333,15 +337,21 @@ export class StructureXmlParserService {
     return 'app-exponent-' + uuid;
   }
 
-  private getApparatusEntryOrDefault(id: string): ApparatusEntry | null {
-    if (!id) return null;
+  private getApparatusEntriesOrDefault(id: string): ApparatusEntry[] {
+    console.log('getApparatusEntriesOrDefault', id);
+    if (!id)
+       return [];
 
-    const appsData = this.getAppsData();
-    const appData = appsData.find(x => x.appFrom?.valueWithoutRef === id || x.appTo?.valueWithoutRef === id);
-    if (!appData) return null;
+    let appDatas = this.getAppsData();
+    appDatas = appDatas.filter(x => x.appFrom?.valueWithoutRef === id || x.appTo?.valueWithoutRef === id);
+    if (!appDatas) return [];
 
-    const app = this.appParser.parse(appData.app)
-    return app as ApparatusEntry;
+    const apps = []
+    for (const appData of appDatas) {
+      const app = this.appParser.parse(appData.app);
+      apps.push(app as ApparatusEntry);
+    }
+    return apps;
   }
 
   private getDocumentApparatusEntries(pages: Page[]): DocumentApparatusEntries {

--- a/src/app/view-modes/collation/collation.component.html
+++ b/src/app/view-modes/collation/collation.component.html
@@ -29,7 +29,7 @@
         <button type="button" class="btn-close" aria-label="Close" (click)="modal.dismiss('Cross click'); onSearchChanged('')"></button>
     </div>
     <div class="modal-body overflow-auto" style="max-height: 80vh;">
-        <input type="text" class="form-control mb-2" placeholder="{{ 'searchWitness' | translate }}" [ngModel]="searchWitness" (ngModelChange)="onSearchChanged($event)"  />
+        <input id="search-input" type="text" class="form-control mb-2" placeholder="{{'searchWitness' | translate }}" [ngModel]="searchWitness" (ngModelChange)="onSearchChanged($event)"  />
         
         <ng-container *ngIf="modalWitnesses$ | async as modalWitnesses">
             <div *ngIf="!modalWitnesses.length">{{ 'noWitnessesAvailable' | translate }}</div>

--- a/src/app/view-modes/collation/collation.component.ts
+++ b/src/app/view-modes/collation/collation.component.ts
@@ -205,7 +205,11 @@ export class CollationComponent implements OnDestroy {
   }
 
   openModal(content: TemplateRef<any>) {
-    this.witnessModalRef = this.modalService.open(content, { ariaLabelledBy: 'modal-basic-title' })
+    this.witnessModalRef = this.modalService.open(content, { ariaLabelledBy: 'modal-basic-title' });
+    setTimeout(() => {
+      const input = document.getElementById('search-input');
+      input?.focus();
+    }, 500);
   }
   closeModal() {
     this.modalService.close(this.witnessModalRef);


### PR DESCRIPTION
Due to using the array.find() function instead of array.filter(), some apparatus entries were skipped, because only the first one matching the function expression was returned.

Also added autofocus for witnesses modal search input and added to apparatus entries ordering by exponent.