### PR TITLE
Changed WitnessIdComponent to being reusable and added to collation witnesses modal. Also Resp attribute has been added to the apparatus boxes.

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -161,6 +161,7 @@ import { HrComponent } from './ui-components/hr/hr.component';
 import { ErrorsButtonComponent } from './main-header/errors-button/errors-button.component';
 import { ReadingMetadataComponent } from './components/reading-metadata/reading-metadata.component';
 import { LabelComponent } from './components/label/label.component';
+import { WitnessRespMetadataComponent } from './components/witness-metadata/witness-resp-metadata/witness-resp-metadata.component';
 
 const routes: Routes = [
 ];
@@ -310,6 +311,7 @@ const DynamicComponents = [
     ErrorsButtonComponent,
     ReadingMetadataComponent,
     LabelComponent,
+    WitnessRespMetadataComponent,
   ],
   imports: [
     AppRoutingModule,

--- a/src/app/components/apparatus-entry/apparatus-entry-detail/apparatus-entry-detail.component.html
+++ b/src/app/components/apparatus-entry/apparatus-entry-detail/apparatus-entry-detail.component.html
@@ -31,6 +31,10 @@
                             <evt-witness-metadata
                                 [witnessMetadata]="readingItem.reading.attributes.wit"></evt-witness-metadata>
                         </span>
+                        <span *ngIf="readingItem.reading.attributes.resp" class="d-flex align-items-start">
+                            <span class="info-label px-2 fw-bold">Resp:</span>
+                            <evt-witness-resp-metadata [ids]="readingItem.reading.attributes.resp"></evt-witness-resp-metadata>
+                        </span>
                     </div>
                 </div>
             </div>
@@ -131,8 +135,13 @@
                                 <evt-witness-metadata
                                     [witnessMetadata]="readingItem.reading.attributes.wit"></evt-witness-metadata>
                             </span>
+                            <span *ngIf="readingItem.reading.attributes.resp" class="d-flex align-items-start">
+                                <span class="info-label pe-2">Resp:</span>
+                                <evt-witness-resp-metadata [ids]="readingItem.reading.attributes.resp"></evt-witness-resp-metadata>
+                            </span>
+
                             <ng-container *ngFor="let metadata of readingItem.reading.attributes | keyvalue">
-                                <span class="d-block pe-2" *ngIf="metadata.key !== 'wit'">
+                                <span class="d-block pe-2" *ngIf="metadata.key !== 'wit' && metadata.key !== 'resp'">
                                     <evt-reading-metadata [metadata]="metadata"></evt-reading-metadata>
                                 </span>
                             </ng-container>

--- a/src/app/components/apparatus-entry/apparatus-entry-detail/apparatus-entry-detail.component.ts
+++ b/src/app/components/apparatus-entry/apparatus-entry-detail/apparatus-entry-detail.component.ts
@@ -8,7 +8,6 @@ import { ApparatusEntryDetailService } from './apparatus-entry-detail.service';
 import { WitnessPanelService } from 'src/app/panels/witness-panel/witness-panel.service';
 import { EditionLevelType } from 'src/app/app.config';
 
-
 @Component({
   selector: 'evt-apparatus-entry-detail',
   templateUrl: './apparatus-entry-detail.component.html',
@@ -118,7 +117,6 @@ export class ApparatusEntryDetailComponent implements OnInit, OnDestroy {
       this.currentTab = tab;
     }
   }
-
 }
 
 export interface ReadingItem {

--- a/src/app/components/named-entities-list/named-entities-list.component.ts
+++ b/src/app/components/named-entities-list/named-entities-list.component.ts
@@ -1,7 +1,9 @@
-import { Component, EventEmitter, Input, OnChanges, OnInit, Output } from '@angular/core';
+import { Component, EventEmitter, Input, OnChanges, OnDestroy, OnInit, Output } from '@angular/core';
 import { NamedEntitiesList } from '../../models/evt-models';
 import { register } from '../../services/component-register.service';
 import { EVTBtnClickEvent } from '../../ui-components/button/button.component';
+import { SearchService } from 'src/app/services/search.service';
+import { Subscription } from 'rxjs';
 
 @register(NamedEntitiesList)
 @Component({
@@ -9,7 +11,7 @@ import { EVTBtnClickEvent } from '../../ui-components/button/button.component';
   templateUrl: './named-entities-list.component.html',
   styleUrls: ['./named-entities-list.component.scss'],
 })
-export class NamedEntitiesListComponent implements OnInit, OnChanges {
+export class NamedEntitiesListComponent implements OnInit, OnChanges, OnDestroy {
   @Input() data: NamedEntitiesList;
   @Output() searchedEntities: EventEmitter<string> = new EventEmitter();
   // tslint:disable-next-line: variable-name
@@ -24,6 +26,18 @@ export class NamedEntitiesListComponent implements OnInit, OnChanges {
   public querySearch = '';
   public querySearchSubmitted = '';
   public caseSensitiveSearch = false;
+  private readonly searchQuerySub: Subscription;
+
+  constructor(
+    private searchService: SearchService
+  ) {
+    this.searchQuerySub = this.searchService.searchQuery$.subscribe(s => {
+      this.searchOpened = true;
+      this.querySearch = s;
+      this.querySearchSubmitted = s;
+      this.searchedEntities.emit(this.querySearch);
+    });
+  }
 
   ngOnInit() {
     this.initKeys();
@@ -31,6 +45,10 @@ export class NamedEntitiesListComponent implements OnInit, OnChanges {
 
   ngOnChanges() {
     this.initKeys();
+  }
+
+  ngOnDestroy(): void {
+    this.searchQuerySub.unsubscribe();
   }
 
   toggleSearch() {

--- a/src/app/components/witness-id/witness-id.component.html
+++ b/src/app/components/witness-id/witness-id.component.html
@@ -1,4 +1,4 @@
-<span class="app-wit link" (click)="onWitnessClicked()">
+<span class="app-wit" [class.clickable]="isClickable" (click)="onWitnessClicked()">
     <ng-container *ngIf="(witnessItem$ | async) as witnessItem;">
         <evt-label *ngIf="witnessItem.label" [data]="witnessItem.label"></evt-label>
         <span *ngIf="witnessItem.id">{{ witnessItem.id }}</span>

--- a/src/app/components/witness-id/witness-id.component.scss
+++ b/src/app/components/witness-id/witness-id.component.scss
@@ -1,6 +1,5 @@
 .app-wit {
-    font-size: 90%;
-        &.link {
+    &.clickable {
         &:hover {
             text-decoration: underline;
             cursor: pointer;

--- a/src/app/components/witness-id/witness-id.component.ts
+++ b/src/app/components/witness-id/witness-id.component.ts
@@ -1,9 +1,7 @@
-import { Component, Input } from '@angular/core';
+import { Component, EventEmitter, Input, Output } from '@angular/core';
 import { map, Observable, shareReplay } from 'rxjs';
 import { Attribute, GenericElement } from 'src/app/models/evt-models';
 import { EVTModelService } from 'src/app/services/evt-model.service';
-import { EVTStatusService } from 'src/app/services/evt-status.service';
-import { ApparatusEntryDetailService } from '../apparatus-entry/apparatus-entry-detail/apparatus-entry-detail.service';
 import { ParseResult } from 'src/app/services/xml-parsers/parser-models';
 
 @Component({
@@ -12,14 +10,14 @@ import { ParseResult } from 'src/app/services/xml-parsers/parser-models';
   styleUrls: ['./witness-id.component.scss']
 })
 export class WitnessIdComponent {
-
   @Input() witnessId: string;
+  @Output() witnessClicked = new EventEmitter<string>();
 
   witnessItem$: Observable<WitnessItem> = this.modelService.flattenedWitnesses$.pipe(
     map(witnesses => {
       const witnessId = Attribute.create(this.witnessId);
       const witness = witnesses.find(y => witnessId.equals(y.id));
-      if(!witness) {
+      if (!witness) {
         console.warn("Cannot find witness with id: ", this.witnessId)
         return;
       }
@@ -29,7 +27,7 @@ export class WitnessIdComponent {
           id: null,
           label: witness.label
         }
-      } 
+      }
       else {
         return { id: witness.id }
       }
@@ -37,23 +35,16 @@ export class WitnessIdComponent {
     shareReplay(1)
   );
 
+  get isClickable() {
+    return this.witnessClicked.observed; // checks if the EventEmitter has been binded in the parent
+  }
+
   constructor(
-    private statusService: EVTStatusService,
     private modelService: EVTModelService,
-    private apparatusEntryDetailService: ApparatusEntryDetailService
   ) { }
 
   onWitnessClicked() {
-    const witnessId = Attribute.create(this.witnessId).valueWithoutRef;
-    this.statusService.updateViewMode$.next(this.statusService.availableViewModes.find(v => v.id === 'collation'));
-    let newValue = [...this.statusService.updateWitnesses$.value, witnessId];
-    newValue = newValue.filter(this.onlyUnique);
-    this.statusService.updateWitnesses$.next(newValue);
-    this.statusService.updateApparatusExponent$.next(this.apparatusEntryDetailService.apparatusEntry.exponent);
-  }
-
-  private onlyUnique(value, index, array) {
-    return array.indexOf(value) === index;
+    this.witnessClicked.emit(this.witnessId);
   }
 }
 

--- a/src/app/components/witness-metadata/witness-metadata.component.html
+++ b/src/app/components/witness-metadata/witness-metadata.component.html
@@ -1,5 +1,5 @@
 <ng-container *ngFor="let witId of this.witnessIds; index as i">
     <span *ngIf="i === 0">{{ ' ' }}</span>
-    <evt-witness-id [witnessId]="witId"></evt-witness-id>
+    <evt-witness-id style="font-size: 90%;" [witnessId]="witId" (witnessClicked)="onWitnessClicked($event)"></evt-witness-id>
     <span *ngIf="i !== (this.witnessIds.length - 1)">{{ ' ' }}</span>
 </ng-container>

--- a/src/app/components/witness-metadata/witness-metadata.component.html
+++ b/src/app/components/witness-metadata/witness-metadata.component.html
@@ -1,5 +1,5 @@
-<ng-container *ngFor="let witId of this.witnessIds; index as i">
+<ng-container *ngFor="let id of this.ids; index as i">
     <span *ngIf="i === 0">{{ ' ' }}</span>
-    <evt-witness-id style="font-size: 90%;" [witnessId]="witId" (witnessClicked)="onWitnessClicked($event)"></evt-witness-id>
-    <span *ngIf="i !== (this.witnessIds.length - 1)">{{ ' ' }}</span>
+    <evt-witness-id style="font-size: 90%;" [witnessId]="id" (witnessClicked)="onWitnessClicked($event)"></evt-witness-id>
+    <span *ngIf="i !== (this.ids.length - 1)">{{ ' ' }}</span>
 </ng-container>

--- a/src/app/components/witness-metadata/witness-metadata.component.ts
+++ b/src/app/components/witness-metadata/witness-metadata.component.ts
@@ -11,7 +11,7 @@ import { ApparatusEntryDetailService } from '../apparatus-entry/apparatus-entry-
 export class WitnessMetadataComponent implements OnInit {
   @Input() witnessMetadata: string;
 
-  witnessIds: string[] = [];
+  ids: string[] = [];
 
   constructor(
     private statusService: EVTStatusService,
@@ -22,10 +22,10 @@ export class WitnessMetadataComponent implements OnInit {
     const witnessMetadata = this.witnessMetadata;
     if (witnessMetadata.includes(' ')) {
       const witnessIds = witnessMetadata.split(' ');
-      this.witnessIds = witnessIds.filter(x => !!x);
+      this.ids = witnessIds.filter(x => !!x);
     }
     else {
-      this.witnessIds = [witnessMetadata];
+      this.ids = [witnessMetadata];
     }
   }
 

--- a/src/app/components/witness-metadata/witness-metadata.component.ts
+++ b/src/app/components/witness-metadata/witness-metadata.component.ts
@@ -1,4 +1,7 @@
 import { Component, Input, OnInit } from '@angular/core';
+import { Attribute } from 'src/app/models/evt-models';
+import { EVTStatusService } from 'src/app/services/evt-status.service';
+import { ApparatusEntryDetailService } from '../apparatus-entry/apparatus-entry-detail/apparatus-entry-detail.service';
 
 @Component({
   selector: 'evt-witness-metadata',
@@ -10,7 +13,10 @@ export class WitnessMetadataComponent implements OnInit {
 
   witnessIds: string[] = [];
 
-  constructor() { }
+  constructor(
+    private statusService: EVTStatusService,
+    private apparatusEntryDetailService: ApparatusEntryDetailService
+  ) { }
 
   ngOnInit(): void {
     const witnessMetadata = this.witnessMetadata;
@@ -21,5 +27,18 @@ export class WitnessMetadataComponent implements OnInit {
     else {
       this.witnessIds = [witnessMetadata];
     }
+  }
+
+  onWitnessClicked(witnessId: string) {
+    const witnessAttrId = Attribute.create(witnessId).valueWithoutRef;
+    this.statusService.updateViewMode$.next(this.statusService.availableViewModes.find(v => v.id === 'collation'));
+    let newValue = [...this.statusService.updateWitnesses$.value, witnessAttrId];
+    newValue = newValue.filter(this.onlyUnique);
+    this.statusService.updateWitnesses$.next(newValue);
+    this.statusService.updateApparatusExponent$.next(this.apparatusEntryDetailService.apparatusEntry.exponent);
+  }
+
+  private onlyUnique(value, index, array) {
+    return array.indexOf(value) === index;
   }
 }

--- a/src/app/components/witness-metadata/witness-resp-metadata/witness-resp-metadata.component.html
+++ b/src/app/components/witness-metadata/witness-resp-metadata/witness-resp-metadata.component.html
@@ -1,0 +1,10 @@
+<ng-container *ngFor="let id of itemIds; index as i">
+    <span class="resp">
+        <span *ngIf="i === 0">{{ ' ' }}</span>
+        <span class="metadata" (click)="onItemClicked(id)">
+            {{ id }}
+        </span>
+        <span *ngIf="i !== (this.ids.length - 1)">{{ ' ' }}</span>
+    </span>
+</ng-container>
+

--- a/src/app/components/witness-metadata/witness-resp-metadata/witness-resp-metadata.component.scss
+++ b/src/app/components/witness-metadata/witness-resp-metadata/witness-resp-metadata.component.scss
@@ -1,0 +1,8 @@
+.resp {
+    font-size: 90%;
+}
+
+.metadata:hover {
+    cursor: pointer;
+    text-decoration: underline;
+}

--- a/src/app/components/witness-metadata/witness-resp-metadata/witness-resp-metadata.component.spec.ts
+++ b/src/app/components/witness-metadata/witness-resp-metadata/witness-resp-metadata.component.spec.ts
@@ -1,0 +1,25 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { WitnessRespMetadataComponent } from './witness-resp-metadata.component';
+
+describe('WitnessRespMetadataComponent', () => {
+  let component: WitnessRespMetadataComponent;
+  let fixture: ComponentFixture<WitnessRespMetadataComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ WitnessRespMetadataComponent ]
+    })
+    .compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(WitnessRespMetadataComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/components/witness-metadata/witness-resp-metadata/witness-resp-metadata.component.ts
+++ b/src/app/components/witness-metadata/witness-resp-metadata/witness-resp-metadata.component.ts
@@ -1,0 +1,40 @@
+import { Component, Input, OnInit } from '@angular/core';
+import { ModalService } from 'src/app/ui-components/modal/modal.service';
+
+@Component({
+  selector: 'evt-witness-resp-metadata',
+  templateUrl: './witness-resp-metadata.component.html',
+  styleUrls: ['./witness-resp-metadata.component.scss']
+})
+export class WitnessRespMetadataComponent implements OnInit {
+
+  @Input() ids: string;
+
+  itemIds: string[] = []
+
+  constructor(
+    private modalService: ModalService
+  ) { }
+
+  ngOnInit(): void {
+    if (!this.ids) return;
+
+    if (this.ids.includes(' ')) {
+      this.itemIds = this.ids.split(' ');
+    }
+    else {
+      this.itemIds = [this.ids];
+    }
+
+    this.itemIds = this.itemIds.map(item => {
+      if (item.startsWith('#')) {
+        item = item.substring(1);
+      }
+      return item;
+    });
+  }
+
+  onItemClicked(id: string) {
+    this.modalService.openGlobalLists(id);
+  }
+}

--- a/src/app/main-header/main-header.component.html
+++ b/src/app/main-header/main-header.component.html
@@ -23,4 +23,4 @@
     </div>
 </nav>
 
-<evt-main-menu *ngIf="mainMenuOpened" (itemClicked)=handleItemClicked($event)></evt-main-menu>
+<evt-main-menu *ngIf="mainMenuOpened" (itemClicked)='handleItemClicked($event)'></evt-main-menu>

--- a/src/app/main-menu/main-menu.component.ts
+++ b/src/app/main-menu/main-menu.component.ts
@@ -6,7 +6,6 @@ import { Observable, of } from 'rxjs';
 import { map } from 'rxjs/operators';
 
 import { AppConfig } from '../app.config';
-import { GlobalListsComponent } from '../components/global-lists/global-lists.component';
 import { ProjectInfoComponent } from '../components/project-info/project-info.component';
 import { EvtInfoComponent } from '../evt-info/evt-info.component';
 import { EVTModelService } from '../services/evt-model.service';
@@ -109,15 +108,7 @@ export class MainMenuComponent {
 
   private openGlobalDialogLists() {
     this.itemClicked.emit('lists');
-    const modalRef = this.modalService.open(ModalComponent, { id: 'global-lists' });
-    const modalComp = modalRef.componentInstance as ModalComponent;
-    modalComp.fixedHeight = true;
-    modalComp.wider = true;
-    modalComp.modalId = 'global-lists';
-    modalComp.title = 'lists';
-    modalComp.bodyContentClass = 'p-0 h-100';
-    modalComp.headerIcon = { icon: 'clipboard-list', iconSet: 'fas', additionalClasses: 'me-3' };
-    modalComp.bodyComponent = GlobalListsComponent;
+    this.modalService.openGlobalLists();
   }
 
   private generateBookmark() {

--- a/src/app/services/search.service.ts
+++ b/src/app/services/search.service.ts
@@ -1,0 +1,18 @@
+import { Injectable } from '@angular/core';
+import { BehaviorSubject } from 'rxjs';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class SearchService {
+
+  private readonly _searchQuery$ = new BehaviorSubject('');
+  readonly searchQuery$ = this._searchQuery$.asObservable();
+
+  constructor() { }
+
+  search(searchQuery: string) {
+    if(!searchQuery) return;
+    this._searchQuery$.next(searchQuery);
+  }
+}

--- a/src/app/ui-components/modal/modal.service.ts
+++ b/src/app/ui-components/modal/modal.service.ts
@@ -1,12 +1,18 @@
 import { Injectable } from '@angular/core';
 import { NgbModal, NgbModalOptions, NgbModalRef } from '@ng-bootstrap/ng-bootstrap';
+import { ModalComponent } from './modal.component';
+import { GlobalListsComponent } from 'src/app/components/global-lists/global-lists.component';
+import { SearchService } from 'src/app/services/search.service';
 
 @Injectable({
   providedIn: 'root',
 })
 export class ModalService {
   private openedModals: { [modalId: string]: NgbModalRef } = {};
-  constructor(private ngbModal: NgbModal) { }
+  constructor(
+    private ngbModal: NgbModal,
+    private searchService: SearchService,
+  ) { }
 
   open(componentToOpen, options?: ModalOptions): NgbModalRef {
     options = {
@@ -27,6 +33,19 @@ export class ModalService {
     } else {
       modalRef.close();
     }
+  }
+
+  openGlobalLists(searchQuery?: string) {
+    const modalRef = this.open(ModalComponent, { id: 'global-lists' });
+    const modalComp = modalRef.componentInstance as ModalComponent;
+    modalComp.fixedHeight = true;
+    modalComp.wider = true;
+    modalComp.modalId = 'global-lists';
+    modalComp.title = 'lists';
+    modalComp.bodyContentClass = 'p-0 h-100';
+    modalComp.headerIcon = { icon: 'clipboard-list', iconSet: 'fas', additionalClasses: 'me-3' };
+    modalComp.bodyComponent = GlobalListsComponent;
+    this.searchService.search(searchQuery);
   }
 }
 

--- a/src/app/view-modes/collation/modal-witness-item/modal-witness-item.component.html
+++ b/src/app/view-modes/collation/modal-witness-item/modal-witness-item.component.html
@@ -2,7 +2,8 @@
     <div class="modal-item d-flex justify-content-between align-items-center py-1" (click)="toggleCollapse()">
         <evt-icon role="button" *ngIf="witness.witnesses.length" [iconInfo]="chevronIcon"
             [attr.aria-expanded]="!isCollapsed"></evt-icon>
-        <span class="ms-2 fs-5">{{ witness.label }}</span>
+        <!-- <span class="ms-2 fs-5">{{ witness.label }}</span> -->
+        <evt-witness-id class="ms-2 fs-5" [witnessId]="witness.id"></evt-witness-id>
 
         <evt-button *ngIf="witness.canSelect" type="button" class="ms-auto" additionalClasses="btn-sm btn-floating"
             [label]="'add' | translate" (btnClick)="onSelectClicked(this.witness.id)"></evt-button>


### PR DESCRIPTION
The WitnessIdComponent had a function called when clicked aswell as custom styling.
Now that function just invokes the EventEmitter and it's supposed to be binded in parent components where it's used.
If no callback is binded than nothing happens on click and styling is removed.
For example now it's being also reused in the Witnesses Modal in the CollationView other than apparatus boxes.

Resp attribute has also been added to the apparatus boxes and each Resp id is clickable, which opens the global list modal with the id as search query, so the corresponding scholar is shown.